### PR TITLE
Specify data file in setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 from setuptools import setup
+import os
 
 setup(
    name='prtools',
@@ -8,4 +9,7 @@ setup(
    author_email='',
    packages=['prtools'],
    install_requires=['sklearn', 'numpy', 'matplotlib', 'requests', 'mlxtend'],
+   package_data={
+      'prtools': [ os.path.join('data', '*.mat') ],
+   },
 )


### PR DESCRIPTION
This ensures that data file are included when setting up the package locally.

Tested by doing a clean install using `pip3` and verified that the `data` directory was indeed present, and usable by running `read mat("hall")` as an example.
(Perhaps someone on a Unix system should verify that this works as well, just to be safe)